### PR TITLE
Memoize tiles

### DIFF
--- a/AssetManager.cpp
+++ b/AssetManager.cpp
@@ -76,4 +76,8 @@ void AssetManager::clear()
         // Delete the asset instance.
         delete i->second;
     }
+    
+    // Now that all the asset hash contains has been deleted, we can
+    // clear out the underlying map.
+    this->assetHash.erase(this->assetHash.begin(), this->assetHash.end());
 }

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -161,6 +161,8 @@ unsigned int Renderer::getHeight()
 void Renderer::addToRenderQueue(tile_type type, Tile * tile)
 {
     this->renderQueue.push_back(TileWithType(type,tile));
+    // Sort the Tiles to cut down on overdraw.
+    std::sort(this->renderQueue.begin(), this->renderQueue.end(), tileSortingPredicate);
 }
 
 void Renderer::flushRenderQueue()
@@ -223,9 +225,6 @@ void Renderer::renderFinalPass()
 
 void Renderer::render(Window * window)
 {
-    // Rendering a bunch of Tiles is a multi-step process. First we
-    // really should sort them to cut down on overdraw.
-    std::sort(this->renderQueue.begin(), this->renderQueue.end(), tileSortingPredicate);
     
     // Bind to the VAO.
     glBindVertexArray( this->tileVAO );

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -158,6 +158,17 @@ unsigned int Renderer::getHeight()
     return this->fwdFB->getHeight();
 }
 
+void Renderer::memoize()
+{
+    unsigned int i = 0;
+    for(std::vector<TileWithType>::iterator it = renderQueue.begin(); it != renderQueue.end(); ++it)
+    {
+        /* it->first: TileType
+         * it->second: Tile* */
+        rqMemo.insert(std::pair<unsigned long, unsigned int>(it->second->getID(), i));
+    }
+}
+
 /**
  * @brief This is used as the predicate when sorting Tiles. It places opaque
  *        from front to back, then transparent Tiles from back to front.

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -165,7 +165,7 @@ void Renderer::memoize()
     {
         /* it->first: TileType
          * it->second: Tile* */
-        rqMemo.insert(std::pair<unsigned long, unsigned int>(it->second->getID(), i));
+        this->rqMemo.insert(IdAndIndex(it->second->getID(), i));
     }
 }
 
@@ -199,6 +199,8 @@ void Renderer::addToRenderQueue(tile_type type, Tile * tile)
     this->renderQueue.push_back(TileWithType(type,tile));
     // Sort the Tiles to cut down on overdraw.
     std::sort(this->renderQueue.begin(), this->renderQueue.end(), tileSortingPredicate);
+    // Now that it's sorted, we need to re-memoize.
+    this->memoize();
 }
 
 void Renderer::flushRenderQueue()

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -158,18 +158,6 @@ unsigned int Renderer::getHeight()
     return this->fwdFB->getHeight();
 }
 
-void Renderer::addToRenderQueue(tile_type type, Tile * tile)
-{
-    this->renderQueue.push_back(TileWithType(type,tile));
-    // Sort the Tiles to cut down on overdraw.
-    std::sort(this->renderQueue.begin(), this->renderQueue.end(), tileSortingPredicate);
-}
-
-void Renderer::flushRenderQueue()
-{
-    this->renderQueue.clear();
-}
-
 /**
  * @brief This is used as the predicate when sorting Tiles. It places opaque
  *        from front to back, then transparent Tiles from back to front.
@@ -193,6 +181,18 @@ bool tileSortingPredicate(TileWithType lhs, TileWithType rhs)
     if( a->getPlane() <= b->getPlane() ) return true;
     if( a->getPlane() >  b->getPlane() ) return false;
     return true; // Just to get rid of the warnings.
+}
+
+void Renderer::addToRenderQueue(tile_type type, Tile * tile)
+{
+    this->renderQueue.push_back(TileWithType(type,tile));
+    // Sort the Tiles to cut down on overdraw.
+    std::sort(this->renderQueue.begin(), this->renderQueue.end(), tileSortingPredicate);
+}
+
+void Renderer::flushRenderQueue()
+{
+    this->renderQueue.clear();
 }
 
 bool Renderer::onScreenTest(Tile * t)

--- a/Renderer.h
+++ b/Renderer.h
@@ -120,7 +120,14 @@ private:
      * one adds Tiles to the renderQueue, and then calls render()
      * to render them all.
      */
-    std::vector< std::pair<tile_type,Tile*> > renderQueue;
+    std::vector< TileWithType > renderQueue;
+    
+    /*
+     * A memoization of all the Tiles' position in the sorted render queue,
+     * so that single Tiles can be removed in O(1) time. It's just a mapping
+     * of Tile IDs to indices.
+     */
+    std::map< unsigned long, unsigned int > rqMemo;
     
     /*
      * After the Tiles are drawn into the framebuffer, we need a

--- a/Renderer.h
+++ b/Renderer.h
@@ -31,6 +31,11 @@ class PostTile;
  */
 typedef std::pair<tile_type, Tile*> TileWithType;
 
+/*
+ * A type definition that links a Tile's ID with its index in the rendering queue.
+ */
+typedef std::pair<unsigned long, unsigned int> IdAndIndex;
+
 /**
  * @class Renderer
  * @author Gerard Geer

--- a/Renderer.h
+++ b/Renderer.h
@@ -286,6 +286,15 @@ public:
     void addToRenderQueue(tile_type type, Tile * tile);
     
     /**
+     * @brief Removes a single Tile from the sorted rendering queue. This does
+     *        not delete the Tile instance the pointer points to.
+     * @param tile The Tile instance to remove.
+     * @return Whether or not the Tile could be removed. If false, the Tile
+     *         was not in the RenderQueue.
+     */
+    bool removeFromRenderQueue(Tile* tile);
+    
+    /**
      * @brief Clears the rendering queue. Note that this doesn't destroy
      *        the Tiles within. It just simply clears out the line of Tiles
      *        waiting to get to be drawn.

--- a/Renderer.h
+++ b/Renderer.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <vector>
 #include <valarray>
+#include <map>
 #include "AssetManager.h"
 #include "Shader.h"
 #include "Texture.h"
@@ -170,6 +171,11 @@ private:
      * @return Whether or not the Tile is on screen.
      */
     bool onScreenTest(Tile * t);
+    
+    /**
+     * @brief Memoizes or re-memoizes the rendering queue.
+     */
+    void memoize();
     
     /**
      * @brief Draws the finished framebuffer onto a full screen Tile and

--- a/Tile.cpp
+++ b/Tile.cpp
@@ -19,6 +19,8 @@ void Tile::init(GLfloat x, GLfloat y, tile_plane plane, GLfloat width, GLfloat h
     this->plane = plane;
     this->trans = trans;
     this->texFlip = 0;
+    // Oh why look at that our unique identifier is already figured out for us.
+    this->id = (unsigned long) this;
 }
 
 GLfloat Tile::getParallaxFactor(tile_plane plane)
@@ -93,6 +95,11 @@ GLuint Tile::getTextureFlip() const
 BasicMatrix * Tile::getMatrix() const
 {
     return this->m;
+}
+
+unsigned long Tile::getID() const
+{
+    return this->id;
 }
 
 void Tile::setX(GLfloat x)

--- a/Tile.h
+++ b/Tile.h
@@ -18,7 +18,13 @@ class Renderer;
  *        renderable element in the engine. Everything is a Tile.
  *        The background, sprites, level blocks, etc. are all Tiles.
  */
- 
+
+/*
+ * Tiles can exist on nine "planes", with BG being the farthest away,
+ * and POS_2 being the one closest to the camera.
+ * Nearer planes scroll faster relative to the camera than farther 
+ * ones, with PLAYFIELD planes scrolling at the same speed as the camera.
+ */
 enum tile_plane
 {
     PLANE_BG = 9,
@@ -33,6 +39,9 @@ enum tile_plane
     PLANE_POS_2 = 0
 };
 
+/*
+ * An enum talking about Tile types so we don't need introspection.
+ */
 enum tile_type
 {
     BG_TILE,
@@ -67,9 +76,23 @@ private:
      */
     GLuint texFlip;
     
+    /*
+     * The ID of this Tile. Used for memoization in the Renderer,
+     * so a single Tile can be removed from the sorted render queue
+     * with 0(1) look-up time.
+     */
+    unsigned long id;
+    
 public:
-
+    
+    /*
+     * A flag stating to flip vertically.
+     */
     static const GLuint FLIP_VERT = 1;
+    
+    /*
+     * A flag stating to flip horizontally.
+     */
     static const GLuint FLIP_HORIZ = 2;
     
     /**
@@ -178,6 +201,12 @@ public:
      * @return A reference to this Tile's underlying BasicMatrix.
      */
     BasicMatrix * getMatrix() const;
+    
+    /**
+     * @brief Returns the unique ID of this Tile.
+     * @return The unique ID of this Tile.
+     */
+    unsigned long getID() const;
     
     /**
      * @brief Changes the X position of this Tile. Useful for animation.


### PR DESCRIPTION
Adds Tile memoization to keep track of Tile positions in the rendering queue after sorting. This is then used to remove a Tile from the sorted rendering queue in O(1) time.
