### PR TITLE
Adding rotation

### DIFF
--- a/BasicMatrix.cpp
+++ b/BasicMatrix.cpp
@@ -68,6 +68,18 @@ void BasicMatrix::set(unsigned int r, unsigned int c, float val)
     this->m[ r*this->columns + c ] = val;
 }
 
+void BasicMatrix::set(BasicMatrix * other)
+{
+    // If the dimensions aren't the same, we can't really do anything.
+    if(this->columns != other->columns || this->rows != other->rows) return;
+    
+    // Otherwise we copy the underlying array.
+    for( unsigned int i = 0; i < this->columns*this->rows; ++i )
+    {
+        this->m[i] = other->m[i];
+    }
+}
+
 void BasicMatrix::multiplyBy(BasicMatrix* rhs)
 {
     // Do dimension test. If it fails, we don't do anything to

--- a/BasicMatrix.h
+++ b/BasicMatrix.h
@@ -102,6 +102,12 @@ public:
     void set(unsigned int r, unsigned int c, float val);
     
     /**
+     * @brief Sets this BasicMatrix' values to that of another. 
+     * @param other The other BasicMatrix.
+     */
+    void set(BasicMatrix * other);
+    
+    /**
      * @brief Multiplies this BasicMatrix by another one.
      * @param rhs The BasicMatrix to be on the right hand side of the operation.
      */

--- a/Tile.cpp
+++ b/Tile.cpp
@@ -6,19 +6,31 @@ Tile::Tile()
 
 Tile::~Tile()
 {
-    delete this->m;
+    delete this->pd;
 }
 
 void Tile::init(GLfloat x, GLfloat y, tile_plane plane, GLfloat width, GLfloat height, bool trans)
 {
-    this->m = new BasicMatrix(3,3);
-    this->m->set(0,2, x);
-    this->m->set(1,2, y);
-    this->m->set(0,0, width);
-    this->m->set(1,1, height);
+    // Create the position and dimension matrix and initialize it. (The modelview matrix).
+    this->pd = new BasicMatrix(3,3);
+    this->pd->set(0,2, x);
+    this->pd->set(1,2, y);
+    this->pd->set(0,0, width);
+    this->pd->set(1,1, height);
+    
+    // Create and initialize the rotation matrix. Since BasicMatrices are initialized to
+    // an identity matrix, we don't need to set any values.
+    this->r = new BasicMatrix(3,3);
+    this->rotation = 0.0; // We do need to store the current rotation.
+    
+    // Create the swap-space matrix.
+    this->mult = new BasicMatrix(3,3);
+    
+    // Store the other stuff.
     this->plane = plane;
     this->trans = trans;
     this->texFlip = 0;
+    
     // Oh why look at that our unique identifier is already figured out for us.
     this->id = (unsigned long) this;
 }
@@ -59,12 +71,12 @@ GLfloat Tile::getTileDepth(tile_plane plane)
 
 GLfloat Tile::getX() const
 {
-    return this->m->get(0,2);
+    return this->pd->get(0,2);
 }
 
 GLfloat Tile::getY() const
 {
-    return this->m->get(1,2);
+    return this->pd->get(1,2);
 }
 
 tile_plane Tile::getPlane() const
@@ -74,12 +86,12 @@ tile_plane Tile::getPlane() const
 
 GLfloat Tile::getWidth() const
 {
-    return this->m->get(0,0);
+    return this->pd->get(0,0);
 }
 
 GLfloat Tile::getHeight() const
 {
-    return this->m->get(1,1);
+    return this->pd->get(1,1);
 }
 
 bool Tile::hasTrans() const
@@ -92,9 +104,24 @@ GLuint Tile::getTextureFlip() const
     return this->texFlip;
 }
 
+GLfloat Tile::getRotation() const
+{
+    return this->rotation;
+}
+
 BasicMatrix * Tile::getMatrix() const
 {
-    return this->m;
+    // Plop the position and dimension matrix into
+    // the swap space matrix.
+    this->mult->set(this->pd);
+    // Multiply that matrix by the rotation matrix.
+    this->mult->multiplyBy(this->r);
+    
+    // Return the swap space matrix. This way neither
+    // of the two important matrices are modified by
+    // this function, and no extraneous matrices are
+    // made.
+    return this->mult;
 }
 
 unsigned long Tile::getID() const
@@ -104,12 +131,12 @@ unsigned long Tile::getID() const
 
 void Tile::setX(GLfloat x)
 {
-    this->m->set(0,2, x);
+    this->pd->set(0,2, x);
 }
 
 void Tile::setY(GLfloat y)
 {
-    this->m->set(1,2, y);
+    this->pd->set(1,2, y);
 }
 
 void Tile::setPlane(tile_plane plane)
@@ -119,17 +146,26 @@ void Tile::setPlane(tile_plane plane)
 
 void Tile::setWidth(GLfloat width)
 {
-    this->m->set(0,0, width);
+    this->pd->set(0,0, width);
 }
 
 void Tile::setHeight(GLfloat height)
 {
-    this->m->set(1,1, height);
+    this->pd->set(1,1, height);
 }
 
 void Tile::setTransparency(bool trans)
 {
     this->trans = trans;
+}
+
+void Tile::setRotation(GLfloat rotation)
+{
+    this->rotation = rotation;
+    this->r->set(0,0,  cos(this->rotation));
+    this->r->set(0,1, -sin(this->rotation));
+    this->r->set(1,0,  sin(this->rotation));
+    this->r->set(1,1,  cos(this->rotation));
 }
 
 void Tile::setTextureFlip(GLuint flip)
@@ -139,5 +175,5 @@ void Tile::setTextureFlip(GLuint flip)
 
 void Tile::destroy()
 {
-    delete this->m;
+    delete this->pd;
 }

--- a/Tile.h
+++ b/Tile.h
@@ -2,6 +2,7 @@
 #define TILE_H
 
 #include <GLFW/glfw3.h>
+#include <cmath>
 #include "BasicMatrix.h"
 
 // Forward definitions of Tile and Renderer since these two
@@ -63,13 +64,30 @@ private:
      * A BasicMatrix that stores this Tile's position and dimensions
      * for easy and efficient shader uniform assignment.
      */
-    BasicMatrix * m;
+    BasicMatrix * pd;
     
+    /*
+     * A BasicMatrix that stores the rotation to be applied to this
+     * Tile.
+     */
+    BasicMatrix * r;
+    
+    /*
+     * A swap-space BasicMatrix so we can multiply without having to
+     * create objects that must be deleted outside of this class.
+     */
+    BasicMatrix * mult;
     
     /*
      * Whether or not this Tile has any transparent regions.
      */
     bool trans;
+    
+    /*
+     * A reference value for the current rotation, since it is not
+     * trivial to extract the value from the rotation matrix.
+     */
+    GLfloat rotation;
     
     /*
      * How to flip the texture, if at all.
@@ -197,6 +215,13 @@ public:
     GLuint getTextureFlip() const;
     
     /**
+     * @brief Returns how much the current Tile has been rotated, in 
+     *        radians.
+     * @return How far the current Tile has been rotated, in radians.
+     */
+    GLfloat getRotation() const;
+    
+    /**
      * @brief Returns a reference to this Tile's underlying BasicMatrix.
      * @return A reference to this Tile's underlying BasicMatrix.
      */
@@ -243,6 +268,12 @@ public:
      * @param Sets whether or not this Tile has transparency.
      */
     void setTransparency(bool trans);
+    
+    /**
+     * @brief Sets the Tile's rotation.
+     * @param rotation How far to rotate the Tile. (In radians)
+     */
+    void setRotation(GLfloat rotation);
     
     /**
      * @brief Sets the texture flip mode. This is a bitwise member, so

--- a/main.cpp
+++ b/main.cpp
@@ -34,6 +34,7 @@ int main(int argc, char **argv)
 
     while(!glfwWindowShouldClose(window.getWindow()))
     {
+        at->setRotation(at->getRotation()+.01);
         window.update();
     }
     window.destroy();


### PR DESCRIPTION
Added a copy function set(BasicMatrix\* other) to BasicMatrix to set the values of one matrix to those of another.
Also added a rotation matrix, and a GLfloat to store the current rotation, to Tile. There's a getter and setter for rotation now, and getMatrix returns the product of the position and rotation matrices, with rotation being done relative to the center of the Tile.
Additionally, a third matrix was added to Tile to compute the product of the position and rotation matrices without creating an extra object each frame.
