### PR TITLE
Move critical assets out of userspace

### DIFF
--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -96,10 +96,17 @@ private:
      * This Asset Manager is used for keeping the things Tiles
      * need to be drawn. This Renderer is passed to the Tiles'
      * render() function, and from there they will have access
-     * to everything they need. Including the shared and only
-     * transformed for each Tile geometry.
+     * to their Textures and in the case of PostTiles, their
+     * shaders.
      */
     AssetManager * assets;
+    
+    /*
+     * This AssetManager holds vital Assets such as the default
+     * shaders for the forward Tile types, and the final-pass
+     * shader.
+     */
+    AssetManager * vitalAssets;
     
     /*
      * The handle to the vertex buffer object that stores the
@@ -204,7 +211,7 @@ private:
     /**
      * @brief Destroys the AssetManager.
      */
-    void destroyAssetManager();
+    void destroyAssetManagers();
     
 public:
 

--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -86,6 +86,9 @@ typedef std::pair<unsigned long, unsigned int> IdAndIndex;
 class Renderer
 {
 friend class Window;
+friend class BGTile;
+friend class SceneTile;
+friend class AnimTile;
 
 private:
 

--- a/lib/AnimTile.cpp
+++ b/lib/AnimTile.cpp
@@ -37,7 +37,7 @@ void AnimTile::render(Renderer* r)
     }
     
     // Now let's get some stuff from the asset Manager.
-    Shader * program = (Shader*)r->getAssetManager()->get("anim_tile_shader");
+    Shader * program = (Shader*)r->vitalAssets->get("anim_tile_shader");
     Texture * frames = (Texture*)r->getAssetManager()->get(texture);
     
     // Start using the program.

--- a/lib/BGTile.cpp
+++ b/lib/BGTile.cpp
@@ -23,7 +23,7 @@ void BGTile::setPlane(tile_plane plane)
 void BGTile::render(Renderer * r)
 {
     // Pull the BGTile's shader program out of retirement.
-    Shader * program = (Shader*) r->getAssetManager()->get((char*)"bg_tile_shader");
+    Shader * program = (Shader*) r->vitalAssets->get((char*)"bg_tile_shader");
     
     // Oh also get its texture.
     Texture * tex = (Texture*) r->getAssetManager()->get(this->texture);

--- a/lib/Renderer.cpp
+++ b/lib/Renderer.cpp
@@ -84,8 +84,9 @@ void Renderer::initTileVAO()
 
 bool Renderer::init(GLuint width, GLuint height)
 {
-    // First initialize the Asset Manager.
+    // First initialize the AssetManagers.
     this->assets = new AssetManager();
+    this->vitalAssets = new AssetManager();
     
     // Next initialize the Camera.
     this->camera = new Camera(0.0, 0.0);
@@ -471,15 +472,18 @@ void Renderer::destroyFBOs()
     delete this->defFB;
 }
 
-void Renderer::destroyAssetManager()
+void Renderer::destroyAssetManagers()
 {
     this->assets->clear();
+    this->vitalAssets->clear();
     delete this->assets;
+    delete this->vitalAssets;
 }
 
 void Renderer::destroy()
 {
-    this->destroyAssetManager();
+    this->destroyAssetManagers();
     this->destroyTileVAO();
     this->destroyFBOs();
 }
+

--- a/lib/Renderer.cpp
+++ b/lib/Renderer.cpp
@@ -31,7 +31,7 @@ void Renderer::initStockShaders()
     this->assets->addNewShader("anim_tile_shader", 
                                "../Assets/Rendering Assets/Shaders/anim_tile_shader.vert",
                                "../Assets/Rendering Assets/Shaders/anim_tile_shader.frag");
-    this->assets->addNewShader("final_pass_shader",
+    this->vitalAssets->addNewShader("final_pass_shader",
                                "../Assets/Rendering Assets/Shaders/final_pass_shader.vert",
                                "../Assets/Rendering Assets/Shaders/final_pass_shader.frag");    
 }
@@ -252,7 +252,7 @@ bool Renderer::onScreenTest(Tile * t)
 void Renderer::renderFinalPass()
 {
     // Get the shader that we need for the final pass' screen quad.
-    Shader * program = (Shader*) this->assets->get("final_pass_shader");
+    Shader * program = (Shader*) this->vitalAssets->get("final_pass_shader");
     
     // Tell OpenGL to use that program.
     program->use();

--- a/lib/Renderer.cpp
+++ b/lib/Renderer.cpp
@@ -22,13 +22,13 @@ void Renderer::initPlaceholderTexture()
 
 void Renderer::initStockShaders()
 {
-    this->assets->addNewShader("bg_tile_shader", 
+    this->vitalAssets->addNewShader("bg_tile_shader", 
                                "../Assets/Rendering Assets/Shaders/bg_tile_shader.vert",
                                "../Assets/Rendering Assets/Shaders/bg_tile_shader.frag");
-    this->assets->addNewShader("scene_tile_shader",
+    this->vitalAssets->addNewShader("scene_tile_shader",
                                "../Assets/Rendering Assets/Shaders/scene_tile_shader.vert",
                                "../Assets/Rendering Assets/Shaders/scene_tile_shader.frag");
-    this->assets->addNewShader("anim_tile_shader", 
+    this->vitalAssets->addNewShader("anim_tile_shader", 
                                "../Assets/Rendering Assets/Shaders/anim_tile_shader.vert",
                                "../Assets/Rendering Assets/Shaders/anim_tile_shader.frag");
     this->vitalAssets->addNewShader("final_pass_shader",

--- a/lib/SceneTile.cpp
+++ b/lib/SceneTile.cpp
@@ -17,7 +17,7 @@ void SceneTile::init(GLfloat x, GLfloat y, tile_plane plane, GLfloat width, GLfl
 
 void SceneTile::render(Renderer * r)
 {
-    Shader * program = (Shader*) r->getAssetManager()->get((char*)"scene_tile_shader");
+    Shader * program = (Shader*) r->vitalAssets->get((char*)"scene_tile_shader");
 
     Texture * tex = (Texture*) r->getAssetManager()->get(this->texture);
     


### PR DESCRIPTION
All critical Assets (the stock shaders) are now sourced out of a private AssetManager, rather than the public one of which users have the ability to clear.
