### PR TITLE
Add shader as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,5 +82,6 @@ Dependencies
 - **GLFW** for OpenGL context creation.
 - **GLEW** for OpenGL extension wrangling.
 - **OpenGL 2.1 with ```GL_ext_framebuffer```** so we can have a programmable pipeline and framebuffer objects.
+- **Python** (2 or 3) for the script that consolidates shader code into a header file.
 
 

--- a/glsl-to-header.py
+++ b/glsl-to-header.py
@@ -1,0 +1,216 @@
+#!/usr/local/bin/python
+
+import sys
+import os
+
+"""
+File: glsl-to-header.py
+Author: Gerard Geer (gerarddgeer@gmail.com)
+
+This script simply takes the filenames passed to it as arguments, and
+spits out their contents into several #define directives in a single
+file. This allows the binary to not require a specific directory containing
+the stock shaders for the BGTile, SceneTile, and AnimTile to be distributed
+alongside it.
+
+Since the generated header file is not meant to be human readable (If you
+want to read the shader source, go read the shader source) this removes
+all trailing and leading whitespace as well as documentation.
+
+usage:
+    glsl-to-header <output filepath> <filepath A> <filepath B> ...
+    
+Note: It is highly recommended that you differ your vertex and fragment
+shaders by file extension alone, e.g., use .frag and .vert.
+"""	
+
+"""
+Opens a given filename, and stores its contents as a #define macro
+within a returned String. This also gets rid of whitespace and
+documentation. If you're looking at this as the shader source instead
+of the shader source itself, you deserve to have a bad time. This also
+propends each line with a $ for easy newline replacement after strtok
+deletes them all.
+
+Parameters:
+    name (String): The name of the directive.
+    file (String): The filepath of the file to #define-ify.
+    
+Returns:
+    The directive as a Python String.
+"""
+def createDefineDirective(name, file):
+
+    # Start off the define macro.
+    result = "#define " + str(name) + " "
+    
+    # Open the file.
+    f = open(file)
+    
+    # Whether or not we're within a multiline comment.
+    multiline = False
+    
+    # Go through the file appending each line to the macro.
+    for line in f:
+        
+        # First we strip beginning and trailing whitespace.
+        line = line.strip()
+        
+        # Next we check to see if we're beginning or end of a multiline
+        # comment.
+        if( '/*' in line and '*/' not in line ):
+            line = line[line.index('/*'):]
+            multiline = True;
+            
+        # If we're in a multiline comment and this line contains the 
+        # end token, we need to delete everything up to and including
+        # the end token.
+        if( '*/' in line and multiline ):
+            line = line[line.index('*/')+2:]
+            multiline = False;
+            
+        # If we're in a multiline comment we don't need to do anything.
+        if( multiline ):
+            continue
+        
+        # If we're not we need to remove any segment comments.
+        # The ones that are like this /* stuff commented out */
+        if( not multiline ):
+            # Get the start of the comment and end of the comment
+            # and cut out what's in between (including the comment
+            # tokens.
+            if( '/*' in line and '*/' in line ):
+                line = line[:line.index('/*')] + line[line.index('*/')+2:]
+        
+        # Check for single line comments.
+        if( '//' in line ):
+            line = line[:line.index('//')]
+                
+        
+        # We need to strip the newline out of the original line so we can
+        # place a closing " and tab before the carriage return.
+        line = line.translate(None, "\n")
+        
+        # If this removes all characters in the line that means we just
+        # deleted an empty line.
+        if( len(line) == 0 ):
+            continue
+        
+        # Finally we append the line of source to the macro we're creating.
+        # We encase in quotation, with a newline thrown in there at the end.
+        # There's also a $ at the end of the line. Why? That's a character
+        # disallowed by the GLSL compiler, so it will never be present in
+        # valid source. Because of this we can use it as a token to replace
+        # with a newline since strtok will destroy the normal newline characters. 
+        result += '"' + str(line) + '$\\n"\t\\\n'
+     
+    # Finally we return the resultant macro, without the last continutation
+    # character or newline.
+    return result[:-2] if ( len(result)>2 ) else result
+    
+"""
+Filenames normally can't be used as variable or macro names, because they
+can have spaces or other barred characters, not to mention extensions.
+This clears all that up.
+
+Parameters:
+    filename (String): The filename to convert to a macro name.
+
+Returns:
+    The macro name.
+"""
+def filenameToMacroName(filename):
+
+    # Get the name of the file from the path.
+    name = os.path.basename(filename)
+    
+    # Split the name and extension.
+    split = os.path.splitext(name)
+    
+    # Since shader type is often only differed by extension,
+    # we need to append the extension to the name if it's
+    # .frag or .glsl
+    if(len(split) > 1): # If we even had an extension.
+        # If the filename was frag or vert
+        if(split[1] == '.vert' or split[1] == '.frag'):
+            # Replaces the . with an underscore.
+            name = split[0] + '_' + split[1][1:]
+        else:
+            name = split[0]
+    
+    # Replace spaces with underscores.
+    name = name.replace(' ', '_')
+    
+    # Remove invalid characters.
+    name = name.translate(None, "!@#$%^&*()+-=,.<>/?;:'[{]}|`~\n\t\\\0\"\b\a\f\v");
+    
+    # Remove leading numbers.
+    while(name[0].isdigit()):
+        name = name[1:]
+    
+    # Finally we return the results of our labor.
+    return name
+        
+"""
+Simply prints usage methodology.
+
+Parameters: None.
+
+Returns: None.
+"""
+def printUsage():
+    print("usage:")
+    print("\tglsl-to-header <output filepath> <filepath A> <filepath B> ...")
+    
+"""
+Main function of the script.
+"""
+def main():
+
+    # Provide the user with help if requested.
+    if("-h" in sys.argv or "--help" in sys.argv):
+        printUsage()
+        return
+        
+    # Check to make sure we've got the correct number of arguments.
+    if(len(sys.argv) == 1):
+        printUsage()
+    if(len(sys.argv) == 2):
+        print("It seems you've either not specified even one GLSL file, or a single GLSL file and no output file. See -h or --help for usage.")
+        
+    # Make an include guard name.
+    guard = filenameToMacroName(sys.argv[1]).upper()
+    
+    # Now we go ahead and make the header file.
+    output = '// Shader source headerfile generated by glsl-to-header.py, written by Gerard Geer\n\n'
+    output += '#ifndef '+guard+'\n'
+    output += '#define '+guard+'\n\n'
+    for filename in sys.argv[2:]:
+        print('  -'+str(filename))
+        output += createDefineDirective(filenameToMacroName(filename),filename)
+        output += '\n\n'
+    
+    # Close the guard directive.
+    output += '#endif // '+guard+'\n\n'
+    
+    # Now that the header file is made, we need to write it to a file.
+    print('Writing to file "'+sys.argv[1]+'"')
+    
+    # If you try to write to a directory that doesn't exist, things tend to
+    # blow up. Let's stop that before such happens.
+    try:
+        file = open(sys.argv[1], 'w')
+    except IOError:
+        print("Error: Could not create output file. Tip: If writing to a directory, it must exist first.")
+        return
+        
+    # Write the header to the output file.
+    file.write(output)
+    print("Done creating shader header file. "+str(len(sys.argv[2:]))+" files were consolidated.")
+    
+"""
+If we've been called directly, we need to execute.
+"""
+if( __name__ == "__main__"):
+    main()
+    

--- a/include/AssetManager.h
+++ b/include/AssetManager.h
@@ -84,6 +84,15 @@ public:
     shader_error addNewShader(const char * key, const char * vertPath, const char * fragPath);
     
     /**
+     * @brief Creates and adds a new Shader from source strings rather than file.
+     * @param key The key to associate this Shader with.
+     * @param vertString The vertex shader source.
+     * @param fragString The fragment shader source.
+     * @return A shader_error. If no error occurred, SHADER_NO_ERROR is returned.
+     */
+    shader_error addNewShaderStrings(const char * key, const char * vertString, const char * fragString);
+    
+    /**
      * @brief Tests whether an Asset exists in the Manager.
      * @param key The key associated with the Asset.
      * @return Whether or not the Asset exists in the Manager.

--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -16,6 +16,7 @@
 #include "PostTile.h"
 #include "Framebuffer.h"
 #include "Window.h"
+#include "shader_source.h"
 
 // All of these classes include Renderer.h, and so in that
 // include, these classes aren't yet defined. Therefore we

--- a/include/Shader.h
+++ b/include/Shader.h
@@ -143,11 +143,11 @@ public:
      * @brief Creates a shader from two strings containing source code, rather than
      *		  loading it from file. Note, this expects the strings to be formatted
      * 		  as by glsl-to-header, with a $ at the end of every line.
-     * @param vertSource The source code string of the vertex shader.
-     * @param fragSource The source code string of the fragment shader.
+     * @param vertString The source code string of the vertex shader.
+     * @param fragString The source code string of the fragment shader.
      * @return A shader_error, if any.
      */
-    shader_error loadStrings(char* vertSource, char* fragSource);
+    shader_error loadStrings(char* vertString, char* fragString);
     
     /**
      * @brief Creates a new ShaderUniform instance and adds it to this shader

--- a/include/Shader.h
+++ b/include/Shader.h
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include "Asset.h"
 #include "ShaderUniform.h"
+#include "shader_source.h"
 
 /*
  * Error codes:
@@ -55,6 +56,23 @@ private:
      * @return A string telling us in plain English what stage we're working with.
      */
     static const char * getShaderType(GLenum type);
+    
+    /**
+     * @brief Traverses a string (in reverse, since we'll be looking for trailing chars)
+     * 	  	  and replaces any occurences of old with replacement.
+     * @param src The string to operate on.
+     * @param old The character to look out for and replace.
+     * @param replacement The character to replace occurences of old with.
+     */
+    static void replaceChar(char* src, char old, char replacement);
+    
+    /**
+     * @brief Parses a source string, splitting it into the required string array.
+     * @param src The source string.
+     * @param dst A pointer to the array of strings, which will be set up by this function.
+     * @return The number of lines in the array.
+     */
+    int parseSourceString(char * source, char *** dst);
     
     /**
      * @brief Scans a single line of source for "uniform <type> <identifier>;"

--- a/include/Shader.h
+++ b/include/Shader.h
@@ -82,13 +82,14 @@ private:
     static shader_error loadSource(char* filename, char*** source, int* numLines);
     
     /**
-     * @brief Loads and compiles a shader object. Any compilation errors are directed to stderr.
-     * @param filename The filename of the shader source code.
+     * @brief Instantiates a shader object on the GPU. Any compilation errors are
+     * directed to stderr.
+     * @param source A pointer to an array of strings that is the source code.
      * @param type The type of shader.
      * @param shaderID A pointer to a GLuint where the new shader ID will be placed.
      * @return A shader_error, if any.
      */
-    static shader_error initShader(char *filename, GLenum type, GLuint *shaderID);
+    static shader_error initShader(char *** source, int numLines, GLenum type, GLuint *shaderID);
     
     /**
      * @brief Takes the IDs of two compiled shader stages and links them into the shader

--- a/include/Shader.h
+++ b/include/Shader.h
@@ -123,7 +123,8 @@ public:
     
     /**
      * @brief Creates a shader from two strings containing source code, rather than
-     *		  loading it from file.
+     *		  loading it from file. Note, this expects the strings to be formatted
+     * 		  as by glsl-to-header, with a $ at the end of every line.
      * @param vertSource The source code string of the vertex shader.
      * @param fragSource The source code string of the fragment shader.
      * @return A shader_error, if any.

--- a/include/Shader.h
+++ b/include/Shader.h
@@ -122,6 +122,15 @@ public:
     shader_error load(char* vertFile, char* fragFile);
     
     /**
+     * @brief Creates a shader from two strings containing source code, rather than
+     *		  loading it from file.
+     * @param vertSource The source code string of the vertex shader.
+     * @param fragSource The source code string of the fragment shader.
+     * @return A shader_error, if any.
+     */
+    shader_error loadStrings(char* vertSource, char* fragSource);
+    
+    /**
      * @brief Creates a new ShaderUniform instance and adds it to this shader
      *        for later use. Any errors this function may generate will be
      *        caught by glGetError().

--- a/include/Shader.h
+++ b/include/Shader.h
@@ -147,7 +147,7 @@ public:
      * @param fragString The source code string of the fragment shader.
      * @return A shader_error, if any.
      */
-    shader_error loadStrings(char* vertString, char* fragString);
+    shader_error loadStrings(const char* vertString, const char* fragString);
     
     /**
      * @brief Creates a new ShaderUniform instance and adds it to this shader

--- a/include/Shader.h
+++ b/include/Shader.h
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 #include "Asset.h"
 #include "ShaderUniform.h"
-#include "shader_source.h"
 
 /*
  * Error codes:

--- a/lib/AssetManager.cpp
+++ b/lib/AssetManager.cpp
@@ -53,6 +53,15 @@ shader_error AssetManager::addNewShader(const char * key, const char * vertPath,
     return this->addNewShader((char*)key, (char*)vertPath, (char*)fragPath);
 }
 
+shader_error AssetManager::addNewShaderStrings(const char * key, const char * vertString, const char * fragString)
+{
+    Shader * s = new Shader();
+    shader_error e = s->loadStrings(vertString, fragString);
+    if( e == SHADER_NO_ERROR ) this->add(key,(Asset*)s);
+    return e;
+}
+	
+
 bool AssetManager::contains(char * key)
 {    
     // The ol' annoying iterator check.

--- a/lib/Renderer.cpp
+++ b/lib/Renderer.cpp
@@ -23,17 +23,17 @@ void Renderer::initPlaceholderTexture()
 void Renderer::initStockShaders()
 {
     this->vitalAssets->addNewShader("bg_tile_shader", 
-                               "../Assets/Rendering Assets/Shaders/bg_tile_shader.vert",
-                               "../Assets/Rendering Assets/Shaders/bg_tile_shader.frag");
+                               "../shaders/bg_tile_shader.vert",
+                               "../shaders/bg_tile_shader.frag");
     this->vitalAssets->addNewShader("scene_tile_shader",
-                               "../Assets/Rendering Assets/Shaders/scene_tile_shader.vert",
-                               "../Assets/Rendering Assets/Shaders/scene_tile_shader.frag");
+                               "../shaders/scene_tile_shader.vert",
+                               "../shaders/scene_tile_shader.frag");
     this->vitalAssets->addNewShader("anim_tile_shader", 
-                               "../Assets/Rendering Assets/Shaders/anim_tile_shader.vert",
-                               "../Assets/Rendering Assets/Shaders/anim_tile_shader.frag");
+                               "../shaders/anim_tile_shader.vert",
+                               "../shaders/anim_tile_shader.frag");
     this->vitalAssets->addNewShader("final_pass_shader",
-                               "../Assets/Rendering Assets/Shaders/final_pass_shader.vert",
-                               "../Assets/Rendering Assets/Shaders/final_pass_shader.frag");    
+                               "../shaders/final_pass_shader.vert",
+                               "../shaders/final_pass_shader.frag");    
 }
 
 void Renderer::initTileVAO()

--- a/lib/Renderer.cpp
+++ b/lib/Renderer.cpp
@@ -22,18 +22,18 @@ void Renderer::initPlaceholderTexture()
 
 void Renderer::initStockShaders()
 {
-    this->vitalAssets->addNewShader("bg_tile_shader", 
-                               "../shaders/bg_tile_shader.vert",
-                               "../shaders/bg_tile_shader.frag");
-    this->vitalAssets->addNewShader("scene_tile_shader",
-                               "../shaders/scene_tile_shader.vert",
-                               "../shaders/scene_tile_shader.frag");
-    this->vitalAssets->addNewShader("anim_tile_shader", 
-                               "../shaders/anim_tile_shader.vert",
-                               "../shaders/anim_tile_shader.frag");
-    this->vitalAssets->addNewShader("final_pass_shader",
-                               "../shaders/final_pass_shader.vert",
-                               "../shaders/final_pass_shader.frag");    
+    this->vitalAssets->addNewShaderStrings("bg_tile_shader", 
+                               bg_tile_shader_vert,
+                               bg_tile_shader_frag);
+    this->vitalAssets->addNewShaderStrings("scene_tile_shader",
+                               scene_tile_shader_vert,
+                               scene_tile_shader_frag);
+    this->vitalAssets->addNewShaderStrings("anim_tile_shader", 
+                               anim_tile_shader_vert,
+                               anim_tile_shader_frag);
+    this->vitalAssets->addNewShaderStrings("final_pass_shader",
+                               final_pass_shader_vert,
+                               final_pass_shader_frag);    
 }
 
 void Renderer::initTileVAO()

--- a/lib/Shader.cpp
+++ b/lib/Shader.cpp
@@ -266,30 +266,39 @@ shader_error Shader::linkShaders(GLuint vertID, GLuint fragID)
 
 shader_error Shader::load(char* vertFile, char* fragFile)
 {
+	// A shader_error in case we need it.
+	shader_error e = SHADER_NO_ERROR;
+	
     // Create individual IDs for each shader stage.
     GLuint vertID = 0, fragID = 0;
     
+    // String arrays for each loaded source.
+    char ** vertSource = NULL; char ** fragSource = NULL;
+    
+    // Line counts for each shader as well.
+    int vertLines = 0, fragLines = 0;
+    
+    // Load the source of each shader.
+    e = loadSource(vertFile, &vertSource, &vertLines);
+    if(e) return e;
+    e = loadSource(fragFile, &fragSource, &fragLines);
+    if(e) return e;
+    
     // Load and compile those shader stages.
-    shader_error e = SHADER_NO_ERROR;
     e = Shader::initShader(vertFile, GL_VERTEX_SHADER, &vertID);
     if(e) return e;
     e = Shader::initShader(fragFile, GL_FRAGMENT_SHADER, &fragID);
     if(e) return e;
+    
     // Now that we've compiled the shaders, we can link them.
     e = linkShaders(vertID, fragID);
     if(e) return e;
     
-    // Now we need to parse for uniforms. Let's just reload the source.
-    char ** vertSource = NULL;
-    char ** fragSource = NULL;
-    int vertLines = 0;
-    int fragLines = 0;
-    this->loadSource(vertFile, &vertSource, &vertLines);
+    // Now we need to parse for uniforms.
     this->scanSourceForUniforms(vertSource, vertLines);
-    this->loadSource(fragFile, &fragSource, &fragLines);
     this->scanSourceForUniforms(fragSource, fragLines);
     
-    // Now that we're done with it (again) we need to free it (again).
+    // Now that we're done with the source code we need to get rid of it.
     for(unsigned int i = 0; i < vertLines; ++i) free(vertSource[i]);
     for(unsigned int i = 0; i < fragLines; ++i) free(fragSource[i]);
     free(vertSource);

--- a/lib/Shader.cpp
+++ b/lib/Shader.cpp
@@ -285,6 +285,11 @@ shader_error Shader::load(char* vertFile, char* fragFile)
     return e;
 }
 
+shader_error Shader::loadStrings(char* vertSource, char* fragSource)
+{
+	return SHADER_NO_ERROR;
+}
+
 void Shader::addUniform(char * name, uniform_type type)
 {
     // Create a new ShaderUniform.

--- a/lib/Shader.cpp
+++ b/lib/Shader.cpp
@@ -336,10 +336,13 @@ shader_error Shader::load(char* vertFile, char* fragFile)
     return e;
 }
 
-shader_error Shader::loadStrings(char* vertString, char* fragString)
+shader_error Shader::loadStrings(const char* vertString, const char* fragString)
 {
 	// A shader_error in case we need it.
 	shader_error e = SHADER_NO_ERROR; // = 0, by the way.
+	
+	// Create modifiable versions of the given strings.
+	char * vs = strdup(vertString); char * fs = strdup(fragString);
 	
     // Create individual IDs for each shader stage.
     GLuint vertID = 0, fragID = 0;
@@ -351,8 +354,8 @@ shader_error Shader::loadStrings(char* vertString, char* fragString)
     int vertLines = 0, fragLines = 0;
     
     // Parse the shader source. 
-    vertLines = Shader::parseSourceString(vertString, &vertSource);
-    fragLines = Shader::parseSourceString(fragString, &fragSource);
+    vertLines = Shader::parseSourceString(vs, &vertSource);
+    fragLines = Shader::parseSourceString(fs, &fragSource);
     
     // Coompile those shader stages.
     if(!e) e = Shader::initShader(&vertSource, vertLines, GL_VERTEX_SHADER, &vertID);
@@ -370,6 +373,8 @@ shader_error Shader::loadStrings(char* vertString, char* fragString)
     for(unsigned int i = 0; i < fragLines; ++i) free(fragSource[i]);
     free(vertSource);
     free(fragSource);
+    free(vs);
+    free(fs);
     
 	return e;
 }

--- a/lib/Shader.cpp
+++ b/lib/Shader.cpp
@@ -21,6 +21,57 @@ const char * Shader::getShaderType(GLenum type)
     }
 }
 
+void Shader::replaceChar(char * src, char old, char replacement)
+{
+	for( int i = strlen(src)-1; i >= 0; --i )
+	{
+		if( src[i] == old ) src[i] = replacement;
+	}
+}
+
+int Shader::parseSourceString(char * src, char *** dst)
+{
+	// How many lines we've encountered so far.
+	int lines = 0;
+	
+	// The current line. I really hope there's not a single line longer than 2000 chars.
+	char * curLine = (char*) malloc( sizeof(char) * 2000 );
+	
+	// Initialize the destination array meant to hold all the lines we cut out.
+	(*dst) = (char**) malloc( sizeof(char*) * (lines+1) );
+	
+	// Go ahead and get the first line.
+	curLine = strtok(src, "\n");
+	
+	// While we still have tokens to get.
+	while( curLine != NULL )
+	{
+		// Duplicate the current line into the current array index.
+		(*dst)[lines] = strdup(curLine);
+		
+		// Now that we've gotten a line, we can increment how many we have.
+		++lines;
+		
+		// Extend the array.
+		(*dst) = (char**) realloc( (*dst), sizeof(char*) * (lines+1) );
+		
+		// Get the next line. WE MIGHT NEED TO CLEAR IT FIRST.
+		curLine = strtok(NULL, "\n");
+	}
+	
+	// Let's get rid of that giant string real quick.
+	free(curLine);
+	
+	// Now we can go through and replace the $ tokens with newlines.
+	for( int i = 0; i < lines; ++i )
+	{
+		Shader::replaceChar((*dst)[i], '$', '\n');
+	}	
+	
+	// Finally we return the number of lines that we've loaded.
+	return lines;	
+}
+
 void Shader::scanLineForUniforms(char* line)
 {
     // Number of tokens found in the line.

--- a/makefile
+++ b/makefile
@@ -79,7 +79,7 @@ $(BLD_DIR)%.o: $(SRC_DIR)%.cpp $(HDR_DIR)%.h
 %.o: $(BLD_DIR)%.o
 
 	
-OBJ_FILES: OBJ_FILES_MESSAGE $(BLD_DIR)Asset.o $(BLD_DIR)AssetManager.o $(BLD_DIR)Texture.o	\
+OBJ_FILES: SHADERS OBJ_FILES_MESSAGE $(BLD_DIR)Asset.o $(BLD_DIR)AssetManager.o $(BLD_DIR)Texture.o	\
 		   $(BLD_DIR)Camera.o $(BLD_DIR)ShaderUniform.o $(BLD_DIR)Shader.o $(BLD_DIR)BasicMatrix.o	\
 		   $(BLD_DIR)Tile.o $(BLD_DIR)BGTile.o $(BLD_DIR)SceneTile.o $(BLD_DIR)AnimTile.o	\
 		   $(BLD_DIR)PostTile.o $(BLD_DIR)Framebuffer.o $(BLD_DIR)Renderer.o $(BLD_DIR)Window.o

--- a/makefile
+++ b/makefile
@@ -55,6 +55,16 @@ setup_dir:
 	@echo "Creating build directory \"$(BLD_DIR)\"."
 	@mkdir -p $(BLD_DIR)
 	@echo "Done creating build directory."
+	
+# Compiles the shader source code files.
+SHADERS:
+	@echo "Consolidating shaders into header file named \"shader_source.h\""
+	@rm -f $(HDR_DIR)shader_source.h
+	@python glsl-to-header.py $(HDR_DIR)shader_source.h \
+							  $(SDR_DIR)bg_tile_shader.vert    $(SDR_DIR)bg_tile_shader.frag       \
+							  $(SDR_DIR)scene_tile_shader.vert $(SDR_DIR)scene_tile_shader.frag \
+							  $(SDR_DIR)anim_tile_shader.vert  $(SDR_DIR)anim_tile_shader.frag   \
+							  $(SDR_DIR)final_pass_shader.vert $(SDR_DIR)final_pass_shader.frag
 
 # Compiles all of Tile2D's source into .o files.
 OBJ_FILES_MESSAGE: setup_dir 

--- a/shaders/anim_tile_shader.frag
+++ b/shaders/anim_tile_shader.frag
@@ -1,0 +1,24 @@
+#version 120
+/**
+ * File: anim_tile_shader.frag
+ * Author: Gerard Geer
+ * License: GPL v3.0
+ * 
+ * This is the AnimTile fragment shader. All the hard work
+ * was done in the vertex shader, so we don't have much left
+ * to do here but sample the texture.
+ */
+ 
+// The texture of this AnimTile.
+uniform sampler2D texture;
+
+// The texture coordinates that have been interpolated for us.
+varying vec2 fragUV;
+
+/**
+ * The shader's entry point.
+ */
+void main(void)
+{
+    gl_FragColor = texture2D(texture, fragUV);
+}

--- a/shaders/anim_tile_shader.vert
+++ b/shaders/anim_tile_shader.vert
@@ -1,0 +1,59 @@
+#version 120
+/**
+ * File: anim_tile_shader.vert
+ * Author: Gerard Geer
+ * License: GPL v3.0
+ *
+ * This is the vertex shader for AnimTiles. AnimTiles store multiple
+ * frames of animation linearly in their texture, and this vertex
+ * shader manipulates the incoming texture coordinates to be centered
+ * on the current frame. We do all the work here so we don't have to
+ * do exponentially more in the fragment shader.
+ */
+ 
+// The VAO's idea of a vertex position. It's a pretty solid idea.
+attribute vec3 vertPos;
+
+// The VAO's interpretation of a texture coordinate. Also solid.
+attribute vec2 vertUV;
+
+// The dimensions of a single frame, expressed as a fraction of the
+// whole texture.
+uniform vec2 fractFrameDim;
+
+// The index of the current frame.
+uniform int curFrame;
+
+// The transformation matrix common to all the Tiles.
+uniform mat3 transform;
+
+// The depth of this AnimTile.
+uniform float depth;
+
+// Texture flip requests.
+uniform int hFlip;
+uniform int vFlip;
+
+// The texture coordinates we're going to send to the fragment stage.
+varying vec2 fragUV;
+
+/**
+ * The entrypoint into the shader.
+ */
+void main(void)
+{
+    // First we do the usual setup of the vertex.
+    gl_Position = vec4( (transform*vertPos).xy, depth, 1.0 );
+    
+    // Now we do the texture coordinates.
+    fragUV = vertUV * fractFrameDim;
+    fragUV.x += fractFrameDim.x * float(curFrame);
+    
+    // If we've got horizontal flip, we need to flip.
+    if( hFlip > 0 ) fragUV.x = 1.0-fragUV.x;
+    
+    // Do the same for horizontal.
+    if( vFlip > 0 ) fragUV.y = 1.0-fragUV.y;
+}
+    
+

--- a/shaders/bg_tile_shader.frag
+++ b/shaders/bg_tile_shader.frag
@@ -1,0 +1,25 @@
+#version 120
+/**
+ * File: bg_tile_shader.frag
+ * Author: Gerard Geer
+ * License: GPL v3.0
+ *
+ * This is the fragment shader for BGTiles. It only needs
+ * to sample the texture and color the current fragment.
+ */
+
+// A sampler bound to the texture unit that we sent this
+// BGTile's texture to.
+uniform sampler2D texture;
+
+// The interpolated texture coordinate we get from the 
+// vertex shader via the rasterizer step.
+varying vec2 fragUV;
+
+/**
+ * The fragment shader entry point.
+ */
+void main(void)
+{
+    gl_FragColor = texture2D(texture, fragUV);
+}

--- a/shaders/bg_tile_shader.vert
+++ b/shaders/bg_tile_shader.vert
@@ -1,0 +1,56 @@
+#version 120
+/**
+ * File: bg_tile_shader.vert
+ * Author: Gerard Geer
+ * License: GPL v3.0
+ *
+ * This is the stock vertex shader for a BGTile. It transforms the
+ * incoming X and Y coordinates by a homogeneous transformation
+ * matrix, then sets the depth to the requested level.
+ */
+
+// The vertex position taken from the VAO.
+attribute vec3 vertPos;
+
+// The vertex texture coorinate, also taken from the VAO.
+attribute vec2 vertUV;
+
+// The transformation matrix. This scales the tile to the
+// appropriate size and moves it to the correct position. This
+// matrix also does parallax scrolling passively.
+uniform mat3 transform;
+
+// The depth of this BGTile. Since it's a BGTile, this value will
+// always be the same.
+uniform float depth;
+
+// Texture flip requests.
+uniform int hFlip;
+uniform int vFlip;
+
+// The texture coordinate that we'll send off to get interpolated
+// and passed to the fragment stage.
+varying vec2 fragUV;
+
+/**
+ * The entry point to this shader.
+ */
+void main(void)
+{
+    // Transform the vertex position, casting it to the correct type.
+    gl_Position = vec4( transform*vertPos, 1.0 );
+    
+    // Now once we set the Z coordinate, we're done. Since the negative
+    // Z axis goes into the screen, a Z coordinate <depth> away would be
+    // at -depth.
+    gl_Position.z = depth;
+    
+    // Get the texture coordinate squared away.
+    fragUV = vertUV;
+    
+    // If we've got horizontal flip, we need to flip.
+    if( hFlip > 0 ) fragUV.x = 1.0-fragUV.x;
+    
+    // Do the same for horizontal.
+    if( vFlip > 0 ) fragUV.y = 1.0-fragUV.y;
+}

--- a/shaders/final_pass_shader.frag
+++ b/shaders/final_pass_shader.frag
@@ -1,0 +1,18 @@
+#version 120
+
+// Interpolated texture coordinates.
+varying vec2 fragUV;
+
+// The first pass' framebuffer.
+uniform sampler2D fwdFB;
+
+// The second pass' framebuffer.
+uniform sampler2D defFB;
+
+void main(void)
+{
+    // Sample the textures and mix based on alpha. That's it!
+    vec4 fwd = texture2D(fwdFB, fragUV);
+    vec4 def = texture2D(defFB, fragUV);
+    gl_FragColor = vec4(mix(fwd.rgb, def.rgb, def.a), 1.0);
+}

--- a/shaders/final_pass_shader.vert
+++ b/shaders/final_pass_shader.vert
@@ -1,0 +1,32 @@
+#version 120
+/**
+ * This is the vertex shader used in compositing the first
+ * and second passes onto a full screen quad.
+ * Since we know the dimensions of the screen, we directly
+ * manipulate vertex coordinates to save the extra
+ * computation of using a matrix.
+ */
+ 
+// The incoming vertex position.
+attribute vec3 vertPos;
+
+// The incoming vertex texture coordinate.
+attribute vec2 vertUV;
+
+// The texture coordinate to be interpolated and sent to the
+// fragment shader.
+varying vec2 fragUV;
+
+void main(void)
+{
+    // Translate the X and Y coordinates to the edge of the screen,
+    // the Z to "really close", and the W to ... something.
+    gl_Position = vec4( vertPos.xy*2.0, 0.0, 1.0 );
+    
+    // We've also got to flip the Y. Since the coordinates range from
+    // -.5 to +.5, we can just negate.
+    gl_Position.y = -gl_Position.y;
+    
+    // Shove the texture coordinate face first into the interpolator.
+    fragUV = vertUV;
+}

--- a/shaders/scene_tile_shader.frag
+++ b/shaders/scene_tile_shader.frag
@@ -1,0 +1,26 @@
+#version 120
+/**
+ * File: scene_tile_shader.frag
+ * Author: Gerard Geer
+ * License: GPL v3.0
+ *
+ * This is the fragment shader for SceneTiles. It only needs
+ * to sample the texture and color the current fragment.
+ */
+
+// A sampler bound to the texture unit that we sent this
+// SceneTile's texture to.
+uniform sampler2D texture;
+
+// The interpolated texture coordinate we get from the 
+// vertex shader.
+varying vec2 fragUV;
+
+/**
+ * The fragment shader entry point.
+ */
+void main(void)
+{
+    // Do some samplin'
+    gl_FragColor = texture2D(texture, fragUV);
+}

--- a/shaders/scene_tile_shader.vert
+++ b/shaders/scene_tile_shader.vert
@@ -1,0 +1,55 @@
+#version 120
+/**
+ * File: scene_tile_shader.vert
+ * Author: Gerard Geer
+ * License: GPL v3.0
+ *
+ * This is the stock vertex shader for a SceneTile. It also transforms
+ * the incoming X and Y coordinates by a homogeneous transformation
+ * matrix, then sets the depth to the requested level.
+ */
+
+// The vertex position taken from the VAO.
+attribute vec3 vertPos;
+
+// The vertex texture coorinate, also taken from the VAO.
+attribute vec2 vertUV;
+
+// The transformation matrix. This scales the tile to the
+// appropriate size and moves it to the correct position. This
+// matrix also does parallax scrolling passively.
+uniform mat3 transform;
+
+// The depth of this SceneTile.
+uniform float depth;
+
+// Texture flip requests.
+uniform int hFlip;
+uniform int vFlip;
+
+// The texture coordinate that we'll send off to get interpolated
+// and passed to the fragment stage.
+varying vec2 fragUV;
+
+/**
+ * The entry point to this shader.
+ */
+void main(void)
+{
+    // Transform the vertex position, casting it to the correct type.
+    gl_Position = vec4( transform*vertPos, 1.0 );
+    
+    // Now once we set the depth, we're done.Since the negative
+    // Z axis goes into the screen, a Z coordinate <depth> away would be
+    // at -depth.
+    gl_Position.z = depth;
+    
+    // Get the texture coordinate squared away.
+    fragUV = vertUV;
+    
+    // If we've got horizontal flip, we need to flip.
+    if( hFlip > 0 ) fragUV.x = 1.0-fragUV.x;
+    
+    // Do the same for horizontal.
+    if( vFlip > 0 ) fragUV.y = 1.0-fragUV.y;
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <cmath>
 #include "tile2d.h"
+#include "shader_source.h"
 
 using namespace std;
 
@@ -10,6 +11,10 @@ int main(int argc, char **argv)
     window.create(1000, 700, 256, 224, (char*)"WOO");
     Renderer * r = window.getRenderer();
     AssetManager * a = r->getAssetManager();
+    
+    Shader * testStrings = new Shader();
+    testStrings->loadStrings(bg_tile_shader_vert, bg_tile_shader_frag);
+    
     a->addNewTexture("puppy", "../Assets/Rendering Assets/Textures/puppy.png");
     
     a->addNewTexture("kitten", "../Assets/Rendering Assets/Textures/kitten.png");

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -12,9 +12,6 @@ int main(int argc, char **argv)
     Renderer * r = window.getRenderer();
     AssetManager * a = r->getAssetManager();
     
-    Shader * testStrings = new Shader();
-    testStrings->loadStrings(bg_tile_shader_vert, bg_tile_shader_frag);
-    
     a->addNewTexture("puppy", "../Assets/Rendering Assets/Textures/puppy.png");
     
     a->addNewTexture("kitten", "../Assets/Rendering Assets/Textures/kitten.png");


### PR DESCRIPTION
This branch removes the renderer's dependency on an Assets directory. To do this it moves the stock, vital shaders to a new directory, adds a script to consolidate shader code to a header file, then has all vital shaders loaded from that header file.
