### PR TITLE
Objectify render queue

### DIFF
--- a/include/RenderQueue.h
+++ b/include/RenderQueue.h
@@ -65,6 +65,19 @@ public:
      */
     void flush();
     
+    /**
+    * @brief Returns the item at the specified index in the queue.
+    * @param index The index to retrieve from.
+	* @return The item at the specified index in the queue.
+    */
+    TileWithType get(unsigned int index);
+    
+    /**
+	 * @brief Returns the size of this RenderQueue.
+	 * @return The size of this RenderQueue.
+	 */
+    unsigned int size();
+    
 };
 
 #endif // RENDERQUEUE_H

--- a/include/RenderQueue.h
+++ b/include/RenderQueue.h
@@ -1,0 +1,70 @@
+#ifndef RENDERQUEUE_H
+#define RENDERQUEUE_H
+
+#include <vector>
+#include <valarray>
+#include <map>
+#include "AssetManager.h"
+#include "Tile.h"
+
+/*
+ * A type definition that links a Tile's ID with its index in the rendering queue.
+ */
+typedef std::pair<unsigned long, unsigned int> IdAndIndex;
+
+class RenderQueue
+{
+private:
+
+    /*
+	 * The vector that we consider to be the queue.
+	 */
+    std::vector< TileWithType > queue;
+    
+    /*
+	 * A map that maps Tile IDs to indices.
+	 */
+    std::map< unsigned long, unsigned int > memo;
+    
+    /**
+     * @brief Memoizes or re-memoizes the rendering queue.
+     */
+    void memoize();
+    
+    /**
+     * @brief This is used as the predicate when sorting Tiles. It places opaque
+     *        from front to back, then transparent Tiles from back to front.
+     * @param lhs The left-hand-side Tile in the comparision.
+     * @param rhs The right-hand-size Tile in the comparison.
+     * @return Whether or not the first one is less than the second.
+     */
+    static bool tileSortingPredicate(TileWithType lhs, TileWithType rhs);
+    
+public:
+    
+    /**
+     * @brief Adds a Tile to the render queue. Whatever is in the render
+     *        queue when Renderer::render() is called will be rendered.
+     * @param tile The Tile to add to the render queue.
+     */
+    void addToRenderQueue(tile_type type, Tile * tile);
+    
+    /**
+     * @brief Removes a single Tile from the sorted rendering queue. This does
+     *        not delete the Tile instance the pointer points to.
+     * @param tile The Tile instance to remove.
+     * @return Whether or not the Tile could be removed. If false, the Tile
+     *         was not in the RenderQueue.
+     */
+    bool removeFromRenderQueue(Tile* tile);
+    
+    /**
+     * @brief Clears the rendering queue. Note that this doesn't destroy
+     *        the Tiles within. It just simply clears out the line of Tiles
+     *        waiting to get to be drawn.
+     */
+    void flush();
+    
+};
+
+#endif // RENDERQUEUE_H

--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -2,9 +2,6 @@
 #define RENDERER_H
 
 #include <iostream>
-#include <vector>
-#include <valarray>
-#include <map>
 #include "AssetManager.h"
 #include "Shader.h"
 #include "Texture.h"
@@ -131,29 +128,14 @@ private:
     char * customCompositor;
     
     /*
-     * The render queue. The way framebuilding works here is that
-     * one adds Tiles to the renderQueue, and then calls render()
-     * to render them all.
+     * The RenderQueue that stores the Tiles of the first pass.
      */
-    std::vector< TileWithType > renderQueue;
-    
-    /*
-     * A memoization of all the Tiles' position in the sorted render queue,
-     * so that single Tiles can be removed in O(1) time. It's just a mapping
-     * of Tile IDs to indices.
-     */
-    std::map< unsigned long, unsigned int > rqMemo;
-    
-    /*
-		 * The RenderQueue that stores the Tiles of the first pass.
-		 */
     RenderQueue * fwdQueue;
     
     /*
-		 * The RenderQueue that sotres the Tiles of the second pass.
-		 */
+	 * The RenderQueue that sotres the Tiles of the second pass.
+	 */
     RenderQueue * defQueue;
-    
     
     /*
      * After the Tiles are drawn into the framebuffer, we need a
@@ -179,6 +161,7 @@ private:
      *        use when DefTiles don't specify one or more of their textures.
      */
     void initPlaceholderTexture();
+    
     /**
      * @brief Loads the stock shaders of the BGTile, SceneTile and AnimTile
      * and puts them in the AssetManager.
@@ -196,11 +179,6 @@ private:
      * @return Whether or not the Tile is on screen.
      */
     bool onScreenTest(Tile * t);
-    
-    /**
-     * @brief Memoizes or re-memoizes the rendering queue.
-     */
-    void memoize();
     
     /**
      * @brief Draws the finished framebuffer onto a full screen Tile and
@@ -222,6 +200,11 @@ private:
      * @brief Destroys the AssetManager.
      */
     void destroyAssetManagers();
+    
+    /**
+	 * @brief Destroys the RenderQueues.
+	 */
+    void destroyRenderQueues();
     
 public:
 

--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -16,6 +16,7 @@
 #include "DefTile.h"
 #include "FwdTile.h"
 #include "Framebuffer.h"
+#include "RenderQueue.h"
 #include "Window.h"
 #include "shader_source.h"
 
@@ -28,11 +29,6 @@ class SceneTile;
 class AnimTile;
 class DefTile;
 class FwdTile;
-
-/*
- * A type definition that links a Tile's ID with its index in the rendering queue.
- */
-typedef std::pair<unsigned long, unsigned int> IdAndIndex;
 
 /**
  * @class Renderer

--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -30,11 +30,6 @@ class DefTile;
 class FwdTile;
 
 /*
- * A type definition that links a Tile with the subclass it was cast from.
- */
-typedef std::pair<tile_type, Tile*> TileWithType;
-
-/*
  * A type definition that links a Tile's ID with its index in the rendering queue.
  */
 typedef std::pair<unsigned long, unsigned int> IdAndIndex;

--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -144,7 +144,14 @@ private:
      */
     std::map< unsigned long, unsigned int > rqMemo;
     
+    /*
+		 * The RenderQueue that stores the Tiles of the first pass.
+		 */
     RenderQueue * fwdQueue;
+    
+    /*
+		 * The RenderQueue that sotres the Tiles of the second pass.
+		 */
     RenderQueue * defQueue;
     
     

--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -144,6 +144,10 @@ private:
      */
     std::map< unsigned long, unsigned int > rqMemo;
     
+    RenderQueue * fwdQueue;
+    RenderQueue * defQueue;
+    
+    
     /*
      * After the Tiles are drawn into the framebuffer, we need a
      * way to draw that framebuffer to the screen. How about atop

--- a/include/Tile.h
+++ b/include/Tile.h
@@ -3,6 +3,8 @@
 
 #include <GLFW/glfw3.h>
 #include <cmath>
+#include <utility>
+
 #include "BasicMatrix.h"
 
 // Forward definitions of Tile and Renderer since these two
@@ -51,6 +53,11 @@ enum tile_type
     DEF_TILE,
     FWD_TILE
 };
+
+/*
+ * A type definition that links a Tile with the subclass it was cast from.
+ */
+typedef std::pair<tile_type, Tile*> TileWithType; 
 
 class Tile
 {

--- a/makefile
+++ b/makefile
@@ -39,15 +39,21 @@ CFLAGS= -c -g -I $(HDR_DIR) $(subst  T2D_, -D T2D_,$(strip $(DBFLAGS)))
 LFLAGS= -lglfw -lGL -lGLU -lpng -lGLEW -lm -lz -ldl
 
 # The source files to be built.
-FILES=$(BLD_DIR)Asset.o $(BLD_DIR)AssetManager.o      \
-	  $(BLD_DIR)Texture.o $(BLD_DIR)ShaderUniform.o   \
-	  $(BLD_DIR)Shader.o $(BLD_DIR)Camera.o           \
-	  $(BLD_DIR)Framebuffer.o $(BLD_DIR)Renderer.o    \
-	  $(BLD_DIR)Window.o $(BLD_DIR)BasicMatrix.o      \
-	  $(BLD_DIR)Tile.o $(BLD_DIR)BGTile.o             \
-	  $(BLD_DIR)SceneTile.o $(BLD_DIR)AnimTile.o      \
-	  $(BLD_DIR)DefTile.o $(BLD_DIR)FwdTile.o
+FILES=$(BLD_DIR)Asset.o 	  $(BLD_DIR)AssetManager.o 		\
+	  $(BLD_DIR)Texture.o 	  $(BLD_DIR)ShaderUniform.o   	\
+	  $(BLD_DIR)Shader.o 	  $(BLD_DIR)Camera.o           	\
+	  $(BLD_DIR)Framebuffer.o $(BLD_DIR)Renderer.o    		\
+	  $(BLD_DIR)Window.o 	  $(BLD_DIR)BasicMatrix.o      	\
+	  $(BLD_DIR)Tile.o 		  $(BLD_DIR)BGTile.o            \
+	  $(BLD_DIR)SceneTile.o   $(BLD_DIR)AnimTile.o      	\
+	  $(BLD_DIR)DefTile.o 	  $(BLD_DIR)FwdTile.o
 	
+# The shader source files to consolidate.
+SHADER_FILES=$(HDR_DIR)shader_source.h \
+			 $(SDR_DIR)bg_tile_shader.vert    $(SDR_DIR)bg_tile_shader.frag        \
+			 $(SDR_DIR)scene_tile_shader.vert $(SDR_DIR)scene_tile_shader.frag     \
+			 $(SDR_DIR)anim_tile_shader.vert  $(SDR_DIR)anim_tile_shader.frag      \
+			 $(SDR_DIR)final_pass_shader.vert $(SDR_DIR)final_pass_shader.frag
 all:
 	@echo ""
 	@echo "Welcome to the Tile2D makefile!"
@@ -113,11 +119,7 @@ setup_library_dir:
 SHADERS:
 	@echo "Consolidating shaders into header file named \"shader_source.h\""
 	@rm -f $(HDR_DIR)shader_source.h
-	@python glsl-to-header.py $(HDR_DIR)shader_source.h \
-							  $(SDR_DIR)bg_tile_shader.vert    $(SDR_DIR)bg_tile_shader.frag        \
-							  $(SDR_DIR)scene_tile_shader.vert $(SDR_DIR)scene_tile_shader.frag     \
-							  $(SDR_DIR)anim_tile_shader.vert  $(SDR_DIR)anim_tile_shader.frag      \
-							  $(SDR_DIR)final_pass_shader.vert $(SDR_DIR)final_pass_shader.frag
+	@python glsl-to-header.py $(SHADER_FILES)
 
 # Compiles all of Tile2D's source into .o files.
 OBJ_FILES_MESSAGE: setup_build_dir 

--- a/makefile
+++ b/makefile
@@ -38,6 +38,16 @@ CFLAGS= -c -g -I $(HDR_DIR) $(subst  T2D_, -D T2D_,$(strip $(DBFLAGS)))
 # Linking flags to make sure everything is bound up tight.
 LFLAGS= -lglfw -lGL -lGLU -lpng -lGLEW -lm -lz -ldl
 
+# The source files to be built.
+FILES=$(BLD_DIR)Asset.o $(BLD_DIR)AssetManager.o      \
+	  $(BLD_DIR)Texture.o $(BLD_DIR)ShaderUniform.o   \
+	  $(BLD_DIR)Shader.o $(BLD_DIR)Camera.o           \
+	  $(BLD_DIR)Framebuffer.o $(BLD_DIR)Renderer.o    \
+	  $(BLD_DIR)Window.o $(BLD_DIR)BasicMatrix.o      \
+	  $(BLD_DIR)Tile.o $(BLD_DIR)BGTile.o             \
+	  $(BLD_DIR)SceneTile.o $(BLD_DIR)AnimTile.o      \
+	  $(BLD_DIR)DefTile.o $(BLD_DIR)FwdTile.o
+	
 all:
 	@echo ""
 	@echo "Welcome to the Tile2D makefile!"
@@ -122,40 +132,21 @@ $(BLD_DIR)%.o: $(SRC_DIR)%.cpp $(HDR_DIR)%.h
 %.o: $(BLD_DIR)%.o
 
 	
-OBJ_FILES: SHADERS OBJ_FILES_MESSAGE $(BLD_DIR)Asset.o $(BLD_DIR)AssetManager.o $(BLD_DIR)Texture.o	\
-		   $(BLD_DIR)Camera.o $(BLD_DIR)ShaderUniform.o $(BLD_DIR)Shader.o $(BLD_DIR)BasicMatrix.o	\
-		   $(BLD_DIR)Tile.o $(BLD_DIR)BGTile.o $(BLD_DIR)SceneTile.o $(BLD_DIR)AnimTile.o	        \
-		   $(BLD_DIR)DefTile.o $(BLD_DIR)FwdTile.o $(BLD_DIR)Framebuffer.o $(BLD_DIR)Renderer.o     \
-           $(BLD_DIR)Window.o
+OBJ_FILES: SHADERS OBJ_FILES_MESSAGE $(FILES)
 	@echo "Done creating object files. Note: some may not have been recompiled."
 	
 # Compiles all of Tile2D into object files then archives them into a
 # static library.
 STATIC: setup_library_dir OBJ_FILES
 	@echo "Using ar to create static library in \"$(LIB_DIR)\" preserving original timestamps."
-	@ar rc $(BLD_DIR)$(ST_NAME) $(BLD_DIR)Asset.o $(BLD_DIR)AssetManager.o      \
-							   $(BLD_DIR)Texture.o $(BLD_DIR)ShaderUniform.o    \
-							   $(BLD_DIR)Shader.o $(BLD_DIR)Camera.o            \
-							   $(BLD_DIR)Framebuffer.o $(BLD_DIR)Renderer.o     \
-							   $(BLD_DIR)Window.o $(BLD_DIR)BasicMatrix.o       \
-							   $(BLD_DIR)Tile.o $(BLD_DIR)BGTile.o              \
-							   $(BLD_DIR)SceneTile.o $(BLD_DIR)AnimTile.o       \
-							   $(BLD_DIR)DefTile.o $(BLD_DIR)FwdTile.o -o -v
+	@ar rc $(BLD_DIR)$(ST_NAME) $(FILES) -o -v
 	@echo "Done archiving."
 							  
 # Compiles Tile2D and links it up with its dependencies (you better have them)
 # into a dynamic library.
 DYNAMIC: setup_library_dir OBJ_FILES
 	@echo "Creating shared library \"$(DY_NAME)\" in \"$(LIB_DIR)\"."
-	@$(CC) -shared $(BLD_DIR)Asset.o $(BLD_DIR)AssetManager.o   \
-				$(BLD_DIR)Texture.o $(BLD_DIR)ShaderUniform.o   \
-				$(BLD_DIR)Shader.o $(BLD_DIR)Camera.o           \
-				$(BLD_DIR)Framebuffer.o $(BLD_DIR)Renderer.o    \
-				$(BLD_DIR)Window.o $(BLD_DIR)BasicMatrix.o      \
-				$(BLD_DIR)Tile.o $(BLD_DIR)BGTile.o             \
-				$(BLD_DIR)SceneTile.o $(BLD_DIR)AnimTile.o      \
-				$(BLD_DIR)DefTile.o $(BLD_DIR)FwdTile.o         \
-				$(LFLAGS) -o $(LIB_DIR)$(DY_NAME)
+	@$(CC) -shared $(FILES) -o $(LIB_DIR)$(DY_NAME)
 	@echo "Done creating shared library."
 	
 # Compiles main.cpp

--- a/makefile
+++ b/makefile
@@ -46,7 +46,8 @@ FILES=$(BLD_DIR)Asset.o 	  $(BLD_DIR)AssetManager.o 		\
 	  $(BLD_DIR)Window.o 	  $(BLD_DIR)BasicMatrix.o      	\
 	  $(BLD_DIR)Tile.o 		  $(BLD_DIR)BGTile.o            \
 	  $(BLD_DIR)SceneTile.o   $(BLD_DIR)AnimTile.o      	\
-	  $(BLD_DIR)DefTile.o 	  $(BLD_DIR)FwdTile.o
+	  $(BLD_DIR)DefTile.o 	  $(BLD_DIR)FwdTile.o			\
+	  $(BLD_DIR)RenderQueue.o
 	
 # The shader source files to consolidate.
 SHADER_FILES=$(HDR_DIR)shader_source.h \

--- a/src/RenderQueue.cpp
+++ b/src/RenderQueue.cpp
@@ -1,0 +1,93 @@
+#include "RenderQueue.h"
+
+void RenderQueue::memoize()
+{
+    // Clear the old memoization first.
+    this->memo.clear();
+    
+    // Iterate over each item in the queue, and hash its index.
+    unsigned int i = 0;
+    for(std::vector<TileWithType>::iterator it = this->queue.begin(); it != this->queue.end(); ++it)
+    {
+        /* it->first: TileType
+         * it->second: Tile* */
+        this->memo.insert(IdAndIndex(it->second->getID(), i));
+        ++i;
+    }
+}
+
+bool RenderQueue::tileSortingPredicate(TileWithType lhs, TileWithType rhs)
+{
+    Tile * a = lhs.second;
+    Tile * b = rhs.second;
+    
+    // Let's first split things up into fwd and def tiles.
+    if( lhs.first == DEF_TILE && rhs.first != DEF_TILE ) return false;
+    if( lhs.first != DEF_TILE && rhs.first == DEF_TILE ) return true;
+    
+    // We need to render transparent objects last.
+    if(  a->hasTrans() && !b->hasTrans() ) return false;
+    if( !a->hasTrans() &&  b->hasTrans() ) return true;
+    
+    // At this point both operands will have the same transparency status.
+    
+    // When Tiles don't have transparency, we can draw them from front to
+    // back and take advantage of z-culling.
+    if( !a->hasTrans() )
+    {
+        // Now we're comparing rendering planes. We want to
+        // draw the closest Tiles first, so we can take
+        // advantage of depth testing and thusly minimize redraw.
+        if( a->getPlane() <= b->getPlane() ) return true;
+        if( a->getPlane() >  b->getPlane() ) return false;
+    }
+    
+    // Otherwise we need to draw from back to front in order for transparency
+    // to work right.
+    else
+    {
+        if( a->getPlane() <= b->getPlane() ) return false;
+        if( a->getPlane() >  b->getPlane() ) return true;
+    }
+    return true; // Just to get rid of the warnings.
+}
+
+void RenderQueue::addToRenderQueue(tile_type type, Tile * tile)
+{
+    // Just tack the Tile on the end since it'll be sorted.
+    this->queue.push_back(TileWithType(type,tile));
+    
+    // Sort the Tiles to cut down on overdraw.
+    std::sort(this->queue.begin(), this->queue.end(), tileSortingPredicate);
+    
+    // Now that it's sorted, we need to re-memoize.
+    this->memoize();
+}
+
+bool RenderQueue::removeFromRenderQueue(Tile* tile)
+{
+    // Check to make sure the Tile is in the memoization.
+    if ( this->memo.find(tile->getID()) != this->memo.end() )
+    {
+        // If it is we get the index of the item from the memoization.
+        unsigned int index = this->memo[tile->getID()];
+        
+        // Use that index to erase.
+        this->queue.erase(this->queue.begin()+index);
+        
+        // Re-memoize the list.
+        this->memoize();
+        
+        // Oh hey we did it! Return true as a reward.
+        return true;
+    }
+    
+    // Didn't exist in the queue! Return false to say so.
+    return false;
+}
+
+void RenderQueue::flush()
+{
+    this->queue.clear();
+    this->memo.clear();
+}

--- a/src/RenderQueue.cpp
+++ b/src/RenderQueue.cpp
@@ -64,6 +64,17 @@ void RenderQueue::addToRenderQueue(tile_type type, Tile * tile)
     this->memoize();
 }
 
+TileWithType RenderQueue::get(unsigned int index)
+{
+    return this->queue.at(index);
+}
+
+unsigned int RenderQueue::size()
+{
+    return this->queue.size();
+}
+
+
 bool RenderQueue::removeFromRenderQueue(Tile* tile)
 {
     // Check to make sure the Tile is in the memoization.

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -262,7 +262,8 @@ bool Renderer::removeFromRenderQueue(Tile* tile)
 
 void Renderer::flushRenderQueue()
 {
-    this->renderQueue.clear();
+    this->fwdQueue->flush();
+    this->defQueue->flush();
 }
 
 bool Renderer::onScreenTest(Tile * t)

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -367,9 +367,9 @@ void Renderer::render(Window * window)
     // Go through and render the forward tiles.
     for(unsigned int i = 0; i < this->fwdQueue->size(); ++i)
     {
-        
+        // Get the current tile.
         t = fwdQueue->get(i);
-        std::cout << "asdf" << std::endl;
+        
         // If this is a DefTile, then we go ahead and save it for later.
         if( t.first == DEF_TILE ) break;
         

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -249,9 +249,14 @@ void Renderer::addToRenderQueue(tile_type type, Tile * tile)
 
 bool Renderer::removeFromRenderQueue(Tile* tile)
 {
-    // Check to make sure the Tile is in the memoization.
+    // Check to see if we could remove it from the fwdQueue.
     if ( fwdQueue->removeFromRenderQueue(tile) ) return true;
+    
+    // If not, then we try the other queue, which is less likely to
+    // be used.
     else if( defQueue->removeFromRenderQueue(tile) ) return true;
+    
+    // If that doesn't work, oh well it didn't exist.
     else return false;
 }
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -250,26 +250,9 @@ void Renderer::addToRenderQueue(tile_type type, Tile * tile)
 bool Renderer::removeFromRenderQueue(Tile* tile)
 {
     // Check to make sure the Tile is in the memoization.
-    if ( this->rqMemo.find(tile->getID()) != this->rqMemo.end() )
-    {
-        // If it is we get the index of the item from the memoization.
-        unsigned int index = this->rqMemo[tile->getID()];
-        
-        // Use that index to erase.
-        renderQueue.erase(renderQueue.begin()+index);
-        
-        // Also erase the memoization entry.
-        rqMemo.erase(tile->getID());
-        
-        this->memoize();
-        
-        // Oh hey we did it! Return true as a reward.
-        return true;
-    }
-    
-    // Didn't exist in the queue! Return false to say so.
-    return false;
-    
+    if ( fwdQueue->removeFromRenderQueue(tile) ) return true;
+    else if( defQueue->removeFromRenderQueue(tile) ) return true;
+    else return false;
 }
 
 void Renderer::flushRenderQueue()

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -88,6 +88,10 @@ bool Renderer::init(GLuint width, GLuint height)
     this->assets = new AssetManager();
     this->vitalAssets = new AssetManager();
     
+    // Next we initialize the RenderQueues.
+    this->fwdQueue = new RenderQueue();
+    this->defQueue = new RenderQueue();
+    
     // Next initialize the Camera.
     this->camera = new Camera(0.0, 0.0);
         

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -180,18 +180,6 @@ unsigned int Renderer::getHeight()
     return this->fwdFB->getHeight();
 }
 
-void Renderer::memoize()
-{
-    unsigned int i = 0;
-    for(std::vector<TileWithType>::iterator it = renderQueue.begin(); it != renderQueue.end(); ++it)
-    {
-        /* it->first: TileType
-         * it->second: Tile* */
-        this->rqMemo.insert(IdAndIndex(it->second->getID(), i));
-        ++i;
-    }
-}
-
 /**
  * @brief This is used as the predicate when sorting Tiles. It places opaque
  *        from front to back, then transparent Tiles from back to front.
@@ -242,12 +230,6 @@ void Renderer::addToRenderQueue(tile_type type, Tile * tile)
         this->fwdQueue->addToRenderQueue(type, tile);
     else
         this->defQueue->addToRenderQueue(type, tile);
-    
-    // Sort the Tiles to cut down on overdraw.
-    //std::sort(this->renderQueue.begin(), this->renderQueue.end(), tileSortingPredicate);
-    
-    // Now that it's sorted, we need to re-memoize.
-    //this->memoize();
 }
 
 bool Renderer::removeFromRenderQueue(Tile* tile)
@@ -656,10 +638,19 @@ void Renderer::destroyAssetManagers()
     delete this->vitalAssets;
 }
 
+void Renderer::destroyRenderQueues()
+{
+    this->fwdQueue->flush();
+    this->defQueue->flush();
+    delete this->fwdQueue;
+    delete this->defQueue;
+}
+
 void Renderer::destroy()
 {
     this->destroyAssetManagers();
     this->destroyTileVAO();
     this->destroyFBOs();
+    this->destroyRenderQueues();
 }
 


### PR DESCRIPTION
This moves the RenderQueue out into its own object, then splits the Tiles of the two passes into two RenderQueue instances (stored upon Renderer) to avoid per-tile-per-frame testing of Tile type. This test is now only performed when a Tile is added.
