### PR TITLE
Internalize framecount

### DIFF
--- a/include/Window.h
+++ b/include/Window.h
@@ -161,7 +161,7 @@ public:
      * @brief Returns the current framecount, or how many frames have been rendered.
      * @return How many frames have been rendered.
      */
-    unsigned long framecount();
+    unsigned long framecount() const;
     
     /**
      * @brief Returns a reference to this window's Renderer.

--- a/include/Window.h
+++ b/include/Window.h
@@ -60,6 +60,11 @@ private:
     bool fullscreen;
     
     /*
+     * The current framecount.
+     */
+    unsigned long fc;
+    
+    /*
      * the underlying GLFWwindow.
      */
     GLFWwindow * baseWindow;
@@ -145,6 +150,18 @@ public:
      * @return The height/vertical resolution of the Window.
      */
     unsigned int getHeight() const;
+    
+    /**
+	 * @brief Returns whether or not this Window is fullscreen.
+	 * @return Whether or not this Window is fullscreen.
+	 */
+    bool isFullscreen() const;
+     
+    /**
+     * @brief Returns the current framecount, or how many frames have been rendered.
+     * @return How many frames have been rendered.
+     */
+    unsigned long framecount();
     
     /**
      * @brief Returns a reference to this window's Renderer.

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -265,6 +265,16 @@ unsigned int Window::getHeight() const
     return this->height;
 }
 
+bool isFullscreen() const
+{
+    return this->fullscreen;
+}
+
+bool framecount() const
+{
+    return this->fc;
+}
+
 Renderer * Window::getRenderer()
 {
     return this->renderer;
@@ -272,7 +282,13 @@ Renderer * Window::getRenderer()
 
 void Window::setAsRenderTarget()
 {
+    // Bind teh current framebuffer to zero, which tells OpenGL
+    // to not actually use a user-defined framebuffer, but to
+    // fall back to the window context itself.
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    
+    // Update the OpenGL state to recognize the dimensions of
+    // the window.
     glViewport(0,0,this->width, this->height);
 }
 
@@ -289,6 +305,9 @@ void Window::update()
     
     // Flip front/back buffers.
     glfwSwapBuffers(this->getWindow());
+    
+    // Increment the framecount.
+    ++fc;
 }
 
 const char * Window::getErrorDesc(window_error e)

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -265,12 +265,12 @@ unsigned int Window::getHeight() const
     return this->height;
 }
 
-bool isFullscreen() const
+bool Window::isFullscreen() const
 {
     return this->fullscreen;
 }
 
-bool framecount() const
+unsigned long Window::framecount() const
 {
     return this->fc;
 }


### PR DESCRIPTION
Adds an internal framecounter to Window, and also adds functionality to query the fullscreen state of the window.
